### PR TITLE
Fix: Restore queue from snapshot when uri attribute is missing -  mp3 playing via http

### DIFF
--- a/.github/workflows/soco-check-jobs.yaml
+++ b/.github/workflows/soco-check-jobs.yaml
@@ -43,9 +43,7 @@ jobs:
           pytest --cov-config .coveragerc --cov soco .
       - name: Test formatting with Black
         if: >-
-          ${{ matrix.python-version == '3.8' ||
-              matrix.python-version == '3.9' ||
-              startsWith(matrix.python-version, '3.1') }}
+          ${{ startsWith(matrix.python-version, '3.1') }}
         run: |
           black --check soco tests
       - name: Test documentation build

--- a/.github/workflows/soco-check-jobs.yaml
+++ b/.github/workflows/soco-check-jobs.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14.0-beta.1"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/soco-check-jobs.yaml
+++ b/.github/workflows/soco-check-jobs.yaml
@@ -43,12 +43,12 @@ jobs:
           pytest --cov-config .coveragerc --cov soco .
       - name: Test formatting with Black
         if: >-
-          ${{ matrix.python-version == "3.8" ||
-              matrix.python-version == "3.9" ||
-              startsWith(matrix.python-version, "3.1") }}
+          ${{ matrix.python-version == '3.8' ||
+              matrix.python-version == '3.9' ||
+              startsWith(matrix.python-version, '3.1') }}
         run: |
           black --check soco tests
       - name: Test documentation build
-        if: matrix.python-version == "3.11"
+        if: matrix.python-version == '3.11'
         run: |
           make docs

--- a/.github/workflows/soco-check-jobs.yaml
+++ b/.github/workflows/soco-check-jobs.yaml
@@ -49,6 +49,6 @@ jobs:
         run: |
           black --check soco tests
       - name: Test documentation build
-        if: matrix.python-version == 3.11
+        if: matrix.python-version == "3.11"
         run: |
           make docs

--- a/.github/workflows/soco-check-jobs.yaml
+++ b/.github/workflows/soco-check-jobs.yaml
@@ -42,7 +42,10 @@ jobs:
         run: |
           pytest --cov-config .coveragerc --cov soco .
       - name: Test formatting with Black
-        if: matrix.python-version >= 3.8
+        if: >-
+          ${{ matrix.python-version == "3.8" ||
+              matrix.python-version == "3.9" ||
+              startsWith(matrix.python-version, "3.1") }}
         run: |
           black --check soco tests
       - name: Test documentation build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,11 +53,14 @@
         "pylint",
         "coveralls",
         "pytest-cov<2.6.0",
-        "wheel", "black >= 22.12.0; python_version >= \"3.7\"",
+        "wheel", "black >= 24.4.0; python_version >= \"3.10\"",
         "requests-mock",
         "twine",
         "importlib-metadata<5; python_version == \"3.7\""
     ]
+
+[tool.black]
+target-version = ["py37"]
 
 [tool.setuptools]
     packages = ["soco", "soco.plugins", "soco.music_services"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ pylint
 coveralls
 pytest-cov<2.6.0
 wheel
-black >= 24.4.0; python_version >= "3.8"
+black >= 24.4.0; python_version >= "3.10"
 requests-mock
 twine
 importlib-metadata<5; python_version == "3.7"

--- a/soco/cache.py
+++ b/soco/cache.py
@@ -7,7 +7,6 @@
 
 """This module contains the classes underlying SoCo's caching system."""
 
-
 import threading
 from pickle import dumps
 from time import time

--- a/soco/core.py
+++ b/soco/core.py
@@ -76,6 +76,7 @@ AUDIO_INPUT_FORMATS = {
     84934716: "Dolby TrueHD 5.1",
     84934718: "Dolby Multichannel PCM 5.1",
     84934721: "DTS 5.1",
+    118489090: "Multichannel PCM 7.1",
     118489146: "Dolby Digital Plus 7.1",
 }
 

--- a/soco/core.py
+++ b/soco/core.py
@@ -1713,12 +1713,14 @@ class SoCo(_SocoSingletonBase):
         The trick seems to be (only tested on a two-speaker setup) to tell each
         speaker which to join. There's probably a bit more to it if multiple
         groups have been defined.
+        Args:
+            kwargs: additional arguments such as timeout.
         """
         # Tell every other visible zone to join this one
         # pylint: disable = expression-not-assigned
         [zone.join(self) for zone in self.visible_zones if zone is not self]
 
-    def join(self, master):
+    def join(self, master, **kwargs):
         """Join this speaker to another "master" speaker."""
 
         self.avTransport.SetAVTransportURI(
@@ -1726,19 +1728,24 @@ class SoCo(_SocoSingletonBase):
                 ("InstanceID", 0),
                 ("CurrentURI", "x-rincon:{}".format(master.uid)),
                 ("CurrentURIMetaData", ""),
-            ]
+            ],
+            **kwargs,
         )
         self.zone_group_state.clear_cache()
 
-    def unjoin(self):
+    def unjoin(self, **kwargs):
         """Remove this speaker from a group.
 
         Seems to work ok even if you remove what was previously the group
         master from it's own group. If the speaker was not in a group also
         returns ok.
+        Args:
+            kwargs: additional arguments such as timeout.
         """
 
-        self.avTransport.BecomeCoordinatorOfStandaloneGroup([("InstanceID", 0)])
+        self.avTransport.BecomeCoordinatorOfStandaloneGroup(
+            [("InstanceID", 0)], **kwargs
+        )
         self.zone_group_state.clear_cache()
 
     def create_stereo_pair(self, rh_slave_speaker):

--- a/soco/core.py
+++ b/soco/core.py
@@ -2,6 +2,7 @@
 """The core module contains the SoCo class that implements
 the main entry to the SoCo functionality
 """
+
 import datetime
 import logging
 import re
@@ -2646,16 +2647,12 @@ class SoCo(_SocoSingletonBase):
             )
         except SoCoUPnPException as err:
             if "Error 402 received" in str(err):
-                raise ValueError(
-                    "invalid sleep_time_seconds, must be integer \
-                    value between 0 and 86399 inclusive or None"
-                ) from err
+                raise ValueError("invalid sleep_time_seconds, must be integer \
+                    value between 0 and 86399 inclusive or None") from err
             raise
         except ValueError as error:
-            raise ValueError(
-                "invalid sleep_time_seconds, must be integer \
-                value between 0 and 86399 inclusive or None"
-            ) from error
+            raise ValueError("invalid sleep_time_seconds, must be integer \
+                value between 0 and 86399 inclusive or None") from error
 
     @only_on_master
     def get_sleep_timer(self):

--- a/soco/data_structure_quirks.py
+++ b/soco/data_structure_quirks.py
@@ -16,7 +16,6 @@ applies them to DIDL-Lite objects.
 
 import logging
 
-
 _LOG = logging.getLogger(__name__)
 
 

--- a/soco/data_structures.py
+++ b/soco/data_structures.py
@@ -1267,9 +1267,7 @@ class ListOfMusicInfoItems(list):
                 dictionary [\'{0}\'] is deprecated. Please use the named
                 attribute {1}.{0} instead. The deprecated way of retrieving the
                 metadata will be removed from the third release after
-                0.8""".format(
-                    key, self.__class__.__name__
-                )
+                0.8""".format(key, self.__class__.__name__)
             message = textwrap.dedent(message).replace("\n", " ").lstrip()
             warnings.warn(message, stacklevel=2)
             return self._metadata[key]

--- a/soco/discovery.py
+++ b/soco/discovery.py
@@ -82,15 +82,13 @@ def discover(
         return _sock
 
     # pylint: disable=invalid-name
-    PLAYER_SEARCH = dedent(
-        """\
+    PLAYER_SEARCH = dedent("""\
         M-SEARCH * HTTP/1.1
         HOST: 239.255.255.250:1900
         MAN: "ssdp:discover"
         MX: 1
         ST: urn:schemas-upnp-org:device:ZonePlayer:1
-        """
-    ).encode("utf-8")
+        """).encode("utf-8")
     MCAST_GRP = "239.255.255.250"
     MCAST_PORT = 1900
 

--- a/soco/events.py
+++ b/soco/events.py
@@ -50,7 +50,6 @@ Example:
 
 """
 
-
 import errno
 import logging
 import socketserver

--- a/soco/events_asyncio.py
+++ b/soco/events_asyncio.py
@@ -70,16 +70,12 @@ import asyncio
 try:
     from aiohttp import ClientSession, ClientTimeout, web
 except ImportError as error:
-    print(
-        """ImportError: {}:
+    print("""ImportError: {}:
     Use of the SoCo events_asyncio module requires the 'aiohttp'
     package and its dependencies to be installed. aiohttp is not
     installed with SoCo by default due to potential issues installing
     the dependencies 'multidict' and 'yarl' on some platforms.
-    See: https://github.com/SoCo/SoCo/issues/819""".format(
-            error
-        )
-    )
+    See: https://github.com/SoCo/SoCo/issues/819""".format(error))
     sys.exit(1)
 
 # Event is imported for compatibility with events.py

--- a/soco/events_base.py
+++ b/soco/events_base.py
@@ -7,7 +7,6 @@
 """Base classes used by :py:mod:`soco.events` and
 :py:mod:`soco.events_twisted`."""
 
-
 import atexit
 from functools import lru_cache
 import logging

--- a/soco/events_twisted.py
+++ b/soco/events_twisted.py
@@ -62,7 +62,6 @@ twisted.python.failure.Failure.html
 
 """
 
-
 import sys
 import logging
 

--- a/soco/music_library.py
+++ b/soco/music_library.py
@@ -7,7 +7,6 @@ The Music Library is the collection of music stored on your local network.
 For access to third party music streaming services, see the
 `music_service` module."""
 
-
 import logging
 
 from urllib.parse import quote as quote_url

--- a/soco/music_services/accounts.py
+++ b/soco/music_services/accounts.py
@@ -3,7 +3,6 @@
 
 """This module contains classes relating to Third Party music services."""
 
-
 import logging
 import weakref
 

--- a/soco/music_services/data_structures.py
+++ b/soco/music_services/data_structures.py
@@ -56,13 +56,13 @@ Class overview:
 
 
 """
+
 from urllib.parse import quote as quote_url
 
 import logging
 from collections import OrderedDict
 from ..data_structures import DidlResource, DidlItem, SearchResult
 from ..utils import camel_to_underscore
-
 
 _LOG = logging.getLogger(__name__)
 _LOG.addHandler(logging.NullHandler())

--- a/soco/music_services/data_structures.py
+++ b/soco/music_services/data_structures.py
@@ -60,7 +60,6 @@ Class overview:
 from urllib.parse import quote as quote_url
 
 import logging
-from collections import OrderedDict
 from ..data_structures import DidlResource, DidlItem, SearchResult
 from ..utils import camel_to_underscore
 
@@ -98,7 +97,7 @@ def parse_response(service, response, search_type):
 
     Args:
         service (MusicService): The music service that produced the response
-        response (OrderedDict): The response from the soap client call
+        response (dict): The response from the soap client call
         search_type (str): A string that indicates the search type that the
             response is from
 
@@ -136,7 +135,7 @@ def parse_response(service, response, search_type):
         result_type_proper = result_type[0].upper() + result_type[1:]
         raw_items = response.get(result_type, [])
         # If there is only 1 result, it is not put in an array
-        if isinstance(raw_items, OrderedDict):
+        if isinstance(raw_items, dict):
             raw_items = [raw_items]
 
         for raw_item in raw_items:
@@ -274,7 +273,7 @@ class MusicServiceItem(MetadataDictBase):
         Args:
             music_service (MusicService): The music service that content_dict
                 originated from
-            content_dict (OrderedDict): The data to instantiate the music
+            content_dict (dict): The data to instantiate the music
                 service item from
 
         Returns:

--- a/soco/music_services/music_service.py
+++ b/soco/music_services/music_service.py
@@ -25,7 +25,6 @@ Known problems:
 
 """
 
-
 import logging
 from urllib.parse import quote as quote_url
 import json

--- a/soco/plugins/__init__.py
+++ b/soco/plugins/__init__.py
@@ -11,7 +11,6 @@ It contains the base class for all plugins
 import logging
 import importlib
 
-
 _LOG = logging.getLogger(__name__)
 
 

--- a/soco/plugins/plex.py
+++ b/soco/plugins/plex.py
@@ -43,7 +43,6 @@ from ..exceptions import SoCoException
 from ..music_services import MusicService
 from ..plugins import SoCoPlugin
 
-
 PREFIX_LOOKUP = {
     "album": "1004206c",
     "artist": "1005004c",

--- a/soco/plugins/sharelink.py
+++ b/soco/plugins/sharelink.py
@@ -226,6 +226,9 @@ class ShareLinkPlugin(SoCoPlugin):
                 added. Default is 0 (add URI at the end of the queue).
             as_next (bool): Whether this URI should be played as the next
                 track in shuffle mode. This only works if "play_mode=SHUFFLE".
+            **kwargs: any keyword arguments. If ``dc_title`` is specified,
+                this will be used as the dc:title of the metadata_template.
+                If not specified, the dc:title will be empty.
 
         Returns:
             int: The index of the new item in the queue.
@@ -239,20 +242,23 @@ class ShareLinkPlugin(SoCoPlugin):
 
                 enqueue_uri = magic[share_type]["prefix"] + encoded_uri
 
+                dc_title = kwargs.pop("dc_title", "")
                 metadata_template = (
                     '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements'
                     '/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata'
                     '-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-'
                     'com:metadata-1-0/" xmlns="urn:schemas-upnp-org:m'
-                    'etadata-1-0/DIDL-Lite/"><item id="{item_id}" res'
-                    'tricted="true"><upnp:class>{item_class}</upnp:cl'
-                    'ass><desc id="cdudn" nameSpace="urn:schemas-rinc'
-                    'onnetworks-com:metadata-1-0/">SA_RINCON{sn}_X_#S'
-                    "vc{sn}-0-Token</desc></item></DIDL-Lite>"
+                    'etadata-1-0/DIDL-Lite/"><item id="{item_id}" par'
+                    'entID="-1" restricted="true"><dc:title>{title}</'
+                    "dc:title><upnp:class>{item_class}</upnp:class><d"
+                    'esc id="cdudn" nameSpace="urn:schemas-rinconnetw'
+                    'orks-com:metadata-1-0/">SA_RINCON{sn}_X_#Svc{sn}'
+                    "-0-Token</desc></item></DIDL-Lite>"
                 )
 
                 metadata = metadata_template.format(
                     item_id=magic[share_type]["key"] + encoded_uri,
+                    title=dc_title,
                     item_class=magic[share_type]["class"],
                     sn=service.service_number(),
                 )

--- a/soco/plugins/sharelink.py
+++ b/soco/plugins/sharelink.py
@@ -237,7 +237,7 @@ class ShareLinkPlugin(SoCoPlugin):
 
         for service in self.services:
             if service.canonical_uri(uri):
-                (share_type, encoded_uri) = service.extract(uri)
+                share_type, encoded_uri = service.extract(uri)
                 magic = service.magic()
 
                 enqueue_uri = magic[share_type]["prefix"] + encoded_uri

--- a/soco/plugins/wimp.py
+++ b/soco/plugins/wimp.py
@@ -2,7 +2,6 @@
 
 """Plugin for the Wimp music service (Service ID 20)"""
 
-
 import locale
 import socket
 

--- a/soco/snapshot.py
+++ b/soco/snapshot.py
@@ -291,7 +291,16 @@ class Snapshot:
             # Now loop around all the queue entries adding them
             for queue_group in self.queue:
                 for queue_item in queue_group:
-                    self.device.add_uri_to_queue(queue_item.uri)
+                    uri = None
+                    # Get Uri from Item if availiable
+                    if hasattr(queue_item, 'uri') and queue_item.uri:
+                        uri = queue_item.uri
+                    # Get Uri from Item.resources if availiable
+                    elif hasattr(queue_item, 'resources') and len(queue_item.resources) > 0 and hasattr(queue_item.resources[0],'uri'):
+                        uri = queue_item.resources[0].uri
+                    # Add uri to queue if found
+                    if uri:
+                        self.device.add_uri_to_queue(uri)
 
     def __enter__(self):
         self.snapshot()

--- a/soco/snapshot.py
+++ b/soco/snapshot.py
@@ -296,7 +296,11 @@ class Snapshot:
                     if hasattr(queue_item, 'uri') and queue_item.uri:
                         uri = queue_item.uri
                     # Get Uri from Item.resources if availiable
-                    elif hasattr(queue_item, 'resources') and len(queue_item.resources) > 0 and hasattr(queue_item.resources[0],'uri'):
+                    elif (
+                        hasattr(queue_item, 'resources') and
+                        len(queue_item.resources) > 0 and
+                        hasattr(queue_item.resources[0], 'uri')
+                    ):
                         uri = queue_item.resources[0].uri
                     # Add uri to queue if found
                     if uri:

--- a/soco/snapshot.py
+++ b/soco/snapshot.py
@@ -291,20 +291,7 @@ class Snapshot:
             # Now loop around all the queue entries adding them
             for queue_group in self.queue:
                 for queue_item in queue_group:
-                    uri = None
-                    # Get Uri from Item if availiable
-                    if hasattr(queue_item, 'uri') and queue_item.uri:
-                        uri = queue_item.uri
-                    # Get Uri from Item.resources if availiable
-                    elif (
-                        hasattr(queue_item, 'resources') and
-                        len(queue_item.resources) > 0 and
-                        hasattr(queue_item.resources[0], 'uri')
-                    ):
-                        uri = queue_item.resources[0].uri
-                    # Add uri to queue if found
-                    if uri:
-                        self.device.add_uri_to_queue(uri)
+                    self.device.add_uri_to_queue(queue_item.get_uri())
 
     def __enter__(self):
         self.snapshot()

--- a/soco/utils.py
+++ b/soco/utils.py
@@ -3,7 +3,6 @@
 
 """This class contains utility functions used internally by SoCo."""
 
-
 import functools
 import re
 import warnings

--- a/soco/xml.py
+++ b/soco/xml.py
@@ -2,12 +2,10 @@
 
 """This class contains XML related utility functions."""
 
-
 import sys
 import re
 
 import xml.etree.ElementTree as XML
-
 
 # Create regular expression for filtering invalid characters, from:
 # http://stackoverflow.com/questions/1707890/

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -857,10 +857,36 @@ class TestAVTransport:
             ]
         )
 
+    def test_join_timeout(self, moco_zgs):
+        """Test join accepts timeout."""
+        moco2 = mock.Mock()
+        moco2.uid = "RINCON_000XXX1400"
+        moco_zgs.avTransport.SetAVTransportURI.reset_mock()
+        moco_zgs.join(moco2, timeout=300)
+        moco_zgs.avTransport.SetAVTransportURI.assert_called_once_with(
+            [
+                ("InstanceID", 0),
+                ("CurrentURI", "x-rincon:RINCON_000XXX1400"),
+                ("CurrentURIMetaData", ""),
+            ],
+            timeout=300,
+        )
+
     def test_unjoin(self, moco_zgs):
         moco_zgs.unjoin()
         moco_zgs.avTransport.BecomeCoordinatorOfStandaloneGroup.assert_called_once_with(
             [("InstanceID", 0)]
+        )
+
+    def test_unjoin_timeout(self, moco_zgs):
+        """Test unjoin accepts timeout."""
+        moco_zgs.avTransport.BecomeCoordinatorOfStandaloneGroup.reset_mock()
+        moco_zgs.unjoin(timeout=300)
+        moco_zgs.avTransport.BecomeCoordinatorOfStandaloneGroup.assert_called_once_with(
+            [
+                ("InstanceID", 0),
+            ],
+            timeout=300,
         )
 
     def test_switch_to_line_in(self, moco_zgs):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,7 +15,6 @@ interrupted at every unit test!
 PLEASE RESPECT THIS.
 """
 
-
 import time
 
 import pytest

--- a/tests/test_ms_data_structures.py
+++ b/tests/test_ms_data_structures.py
@@ -2,7 +2,6 @@
 
 """Unit tests for the music service data structures."""
 
-
 from xml.sax.saxutils import escape
 
 import pytest

--- a/tests/test_music_service_data_structures.py
+++ b/tests/test_music_service_data_structures.py
@@ -118,6 +118,33 @@ RESPONSES.append(
         ]
     )
 )
+# Test case for issue #988: single result returned as plain dict (e.g., Amazon Music)
+RESPONSES.append(
+    {
+        "searchResult": {
+            "index": "0",
+            "count": "1",
+            "total": "1",
+            "mediaMetadata": {
+                "id": "track/amazon123",
+                "title": "Single Result Track",
+                "itemType": "track",
+                "mimeType": "audio/mp4",
+                "trackMetadata": {
+                    "albumArtURI": "http://example.com/art.jpg",
+                    "artistId": "artist/456",
+                    "artist": "Test Artist",
+                    "album": "Test Album",
+                    "duration": "300",
+                    "canPlay": "true",
+                    "canSkip": "true",
+                    "canAddToFavorites": "true",
+                    "trackNumber": "1",
+                },
+            },
+        }
+    }
+)
 PARSE_RESULTS = (
     {
         "number_of_results": 2,
@@ -127,6 +154,12 @@ PARSE_RESULTS = (
     {
         "number_of_results": 1,
         "type": "getMetadataResult",
+        "class_key": "MediaMetadataTrack",
+    },
+    # Test case for issue #988: single result as plain dict
+    {
+        "number_of_results": 1,
+        "type": "searchResult",
         "class_key": "MediaMetadataTrack",
     },
 )
@@ -171,6 +204,19 @@ def test_parse_response(response, correct):
     for result in results:
         assert isinstance(result, klass)
         assert result.music_service is music_service
+
+
+def test_parse_response_plain_dict_fields():
+    """Test that a single result returned as a plain dict (issue #988) parses
+    fields correctly, not just the count and class."""
+    music_service = Mock()
+    music_service.desc = "DESC"
+    results = data_structures.parse_response(music_service, RESPONSES[2], "albums")
+    assert len(results) == 1
+    item = results[0]
+    assert item.title == "Single Result Track"
+    assert item.item_id == "0fffffff" + "track/amazon123"
+    assert item.music_service is music_service
 
 
 def test_parse_response_bad_type():

--- a/tests/test_musicservices.py
+++ b/tests/test_musicservices.py
@@ -8,7 +8,6 @@ from soco.exceptions import MusicServiceException
 from soco.music_services.accounts import Account
 from soco.music_services.music_service import MusicService
 
-
 # Typical account data from http://{Sonos-ip}:1400/status/accounts
 from soco.music_services.token_store import JsonFileTokenStore
 

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,63 @@
+"""Tests for the snapshot module."""
+
+from unittest.mock import MagicMock, call
+
+from soco.data_structures import DidlMusicTrack, DidlResource
+from soco.snapshot import Snapshot
+
+
+def make_track(uri, protocol_info="http-get:*:audio/mpeg:*"):
+    """Create a DidlMusicTrack with a resource URI, as returned by get_queue."""
+    resource = DidlResource(uri=uri, protocol_info=protocol_info)
+    return DidlMusicTrack(
+        title="Test Track",
+        parent_id="Q:0",
+        item_id="Q:0/1",
+        resources=[resource],
+    )
+
+
+def test_restore_queue_calls_add_uri_to_queue(moco):
+    """_restore_queue adds each queue item's URI via add_uri_to_queue."""
+    track1 = make_track("x-file-cifs://nas/music/a.mp3")
+    track2 = make_track("http://192.168.1.50/music/b.mp3")
+
+    snap = Snapshot(moco, snapshot_queue=True)
+    snap.queue = [[track1, track2]]
+
+    moco.add_uri_to_queue = MagicMock()
+    snap._restore_queue()
+
+    moco.add_uri_to_queue.assert_has_calls(
+        [
+            call("x-file-cifs://nas/music/a.mp3"),
+            call("http://192.168.1.50/music/b.mp3"),
+        ]
+    )
+
+
+def test_restore_queue_http_uri(moco):
+    """Tracks added via HTTP (e.g. WebDAV) are correctly restored (issue #983).
+
+    DidlMusicTrack has no direct .uri attribute; the URI lives in resources[0].
+    get_uri() must be used instead.
+    """
+    http_track = make_track("http://192.168.1.50/share/song.mp3")
+    assert not hasattr(http_track, "uri"), "DidlMusicTrack should not have .uri"
+    assert http_track.get_uri() == "http://192.168.1.50/share/song.mp3"
+
+    snap = Snapshot(moco, snapshot_queue=True)
+    snap.queue = [[http_track]]
+
+    moco.add_uri_to_queue = MagicMock()
+    snap._restore_queue()
+
+    moco.add_uri_to_queue.assert_called_once_with("http://192.168.1.50/share/song.mp3")
+
+
+def test_restore_queue_skipped_when_none(moco):
+    """_restore_queue does nothing when queue was not snapshotted."""
+    snap = Snapshot(moco, snapshot_queue=False)
+    moco.add_uri_to_queue = MagicMock()
+    snap._restore_queue()
+    moco.add_uri_to_queue.assert_not_called()

--- a/tests/test_soap.py
+++ b/tests/test_soap.py
@@ -5,7 +5,6 @@ from soco.soap import SoapMessage
 from soco.xml import XML
 from unittest import mock
 
-
 DUMMY_VALID_RESPONSE = "".join(
     [
         '<?xml version="1.0"?>',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,6 @@
 
 from soco.utils import deprecated
 
-
 # Deprecation decorator
 
 


### PR DESCRIPTION
When playing files directly via HTTP (from a WebDAV share), restoring the queue from a snapshot fails with the following error:

```
File "site-packages/soco/snapshot.py", line 294, in _restore_queue
    self.device.add_uri_to_queue(queue_item.uri)
                                                     ^^^^^^^^^^^^
AttributeError: 'DidlMusicTrack' object has no attribute 'uri'
```
[I added the files to the queue by using add_uri_to_queue("http://...")]

This pull request addresses the issue by attempting to retrieve the URI from the item's resources if the uri attribute is not directly available. This ensures compatibility with tracks added from sources like HTTP.
